### PR TITLE
Bug/claudia 5703 wrong response code

### DIFF
--- a/fiware_cloto/cloto/manager/InfoManager.py
+++ b/fiware_cloto/cloto/manager/InfoManager.py
@@ -72,7 +72,7 @@ class InfoManager():
 
         self.publish_message(message)
 
-        logger.info("%s windowsize updated to %d", tenantId, newSize)
+        logger.info("%s windowsize updated to %s", tenantId, str(newSize))
         return t
 
     def setInformations(self, sInfo, tInfo):

--- a/fiware_cloto/cloto/restCloto.py
+++ b/fiware_cloto/cloto/restCloto.py
@@ -121,6 +121,9 @@ class GeneralView(RESTResource):
         except ValidationError as ex:
                 return HttpResponse(json.dumps({"badRequest": {"code": 400, "message":
                     ex.messages[0]}}, indent=4), status=400)
+        except ValueError as ex:
+                return HttpResponse(json.dumps({"badRequest": {"code": 400, "message":
+                    ex.message}}, indent=4), status=400)
 
 
 class GeneralRulesViewRule(RESTResource):

--- a/fiware_cloto/cloto/tests/acceptance_tests/component/tenant_information/features/update_windowsize.feature
+++ b/fiware_cloto/cloto/tests/acceptance_tests/component/tenant_information/features/update_windowsize.feature
@@ -17,7 +17,6 @@ Feature: Policy Manager update window size
         |   10          |
 
 
-    @skip @bug @CLAUDIA-5703
     Scenario Outline: Incorrect update window size requests
 
         Given a created tenant

--- a/fiware_cloto/cloto/tests/tests.py
+++ b/fiware_cloto/cloto/tests/tests.py
@@ -147,7 +147,7 @@ class WindowSizeTests(TestCase):
         self.assertTrue(mock_logging.info.called)
 
     def test_not_update_window(self):
-        """test_not_update_window2 check that PUT windowsize fails with error 400 when an invalid
+        """test_not_update_window check that PUT windowsize fails with error 400 when an invalid
         value is provided in the request"""
         request = self.factory.put('/v1.0/tenantId/', "{\"windowsize\": notValidValue}", "application/json")
 

--- a/fiware_cloto/cloto/tests/tests.py
+++ b/fiware_cloto/cloto/tests/tests.py
@@ -147,7 +147,8 @@ class WindowSizeTests(TestCase):
         self.assertTrue(mock_logging.info.called)
 
     def test_not_update_window(self):
-        # Create an instance of a GET request.
+        """test_not_update_window2 check that PUT windowsize fails with error 400 when an invalid
+        value is provided in the request"""
         request = self.factory.put('/v1.0/tenantId/', "{\"windowsize\": notValidValue}", "application/json")
 
         # Test my_view() as if it were deployed at /customer/details
@@ -155,8 +156,20 @@ class WindowSizeTests(TestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_not_update_window2(self):
-        # Create an instance of a GET request.
+        """test_not_update_window2 check that PUT windowsize fails with error 400 when an invalid
+        numeric value is provided in the request"""
+
         request = self.factory.put('/v1.0/tenantId/', "{\"windowsize\": -1}", "application/json")
+
+        # Test my_view() as if it were deployed at /customer/details
+        response = self.general.PUT(request, "tenantId")
+        self.assertEqual(response.status_code, 400)
+
+    def test_not_update_window_size_with_string(self):
+        """test_not_update_window_size_with_string check that PUT windowsize fails with error 400 when an invalid
+        string is provided in the request
+        """
+        request = self.factory.put('/v1.0/tenantId/', "{\"windowsize\": \"zero\"}", "application/json")
 
         # Test my_view() as if it were deployed at /customer/details
         response = self.general.PUT(request, "tenantId")


### PR DESCRIPTION
### REVIEWERS
@flopezag @jframos 

### DESCRIPTION
- fixing exception block to catch error when some string is updating a windowsize.
- fixing logger info when some valid numeric string is updating a windowsize
- removing skip tag from acceptance scenario after fixing bug CLAUDIA-5703